### PR TITLE
Update documentation

### DIFF
--- a/programs/mpl-inscription/src/processor/write_data.rs
+++ b/programs/mpl-inscription/src/processor/write_data.rs
@@ -123,7 +123,7 @@ pub(crate) fn process_write_data<'a>(
         )?;
     }
 
-    // Write the inscription metadata to the metadata account.
+    // Write the inscription data to the inscription account.
     sol_memcpy(
         &mut ctx.accounts.inscription_account.try_borrow_mut_data()?[args.offset..],
         &args.value,


### PR DESCRIPTION
Comment says _metadata_ account but should be _inscription_ account.
- fix comment on writing inscription data in `write_data.rs` instruction

Source:
https://github.com/metaplex-foundation/mpl-inscription/blob/25f3fdfab5180738370c90e6aa1f5bf091d1ea21/programs/mpl-inscription/src/processor/write_data.rs#L126C1-L131C7 