### PR TITLE
MET-96: Add Inscription support for Token22

### DIFF
--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { createUmi as basecreateUmi } from '@metaplex-foundation/umi-bundle-tests';
-import { Umi } from '@metaplex-foundation/umi';
+import { PublicKey, Umi, publicKey } from '@metaplex-foundation/umi';
 import pMap from 'p-map';
 import {
   mplInscription,
@@ -8,6 +8,10 @@ import {
   findInscriptionShardPda,
   safeFetchInscriptionShard,
 } from '../src';
+
+export const SPL_TOKEN_2022_PROGRAM_ID: PublicKey = publicKey(
+  'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+);
 
 export const createUmi = async () => {
   const umi = (await basecreateUmi()).use(mplInscription());

--- a/clients/js/test/setMint.test.ts
+++ b/clients/js/test/setMint.test.ts
@@ -11,6 +11,8 @@ import {
   mintV1,
   mplTokenMetadata,
 } from '@metaplex-foundation/mpl-token-metadata';
+import { SPL_ASSOCIATED_TOKEN_PROGRAM_ID } from '@metaplex-foundation/mpl-toolbox';
+import { publicKey as publicKeySerializer } from '@metaplex-foundation/umi/serializers';
 import {
   AssociatedInscription,
   DataType,
@@ -23,7 +25,7 @@ import {
   initializeFromMint,
   setMint,
 } from '../src';
-import { createUmi } from './_setup';
+import { createUmi, SPL_TOKEN_2022_PROGRAM_ID } from './_setup';
 
 test('it can set the mint on a Mint Inscription account', async (t) => {
   // Given a Umi instance and a new signer.
@@ -44,10 +46,10 @@ test('it can set the mint on a Mint Inscription account', async (t) => {
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
-  const inscriptionAccount = await findMintInscriptionPda(umi, {
+  const inscriptionAccount = findMintInscriptionPda(umi, {
     mint: mint.publicKey,
   });
-  const inscriptionMetadataAccount = await findInscriptionMetadataPda(umi, {
+  const inscriptionMetadataAccount = findInscriptionMetadataPda(umi, {
     inscriptionAccount: inscriptionAccount[0],
   });
 
@@ -110,7 +112,7 @@ test('it cannot set the mint on an Inscription account that is not derived from 
   // We are creating an inscription account that is not derived from a mint and is not a PDA.
   const inscriptionAccount = generateSigner(umi);
 
-  const inscriptionMetadataAccount = await findInscriptionMetadataPda(umi, {
+  const inscriptionMetadataAccount = findInscriptionMetadataPda(umi, {
     inscriptionAccount: inscriptionAccount.publicKey,
   });
 
@@ -171,10 +173,10 @@ test('it cannot set the wrong mint on a Mint Inscription account', async (t) => 
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
-  const inscriptionAccount = await findMintInscriptionPda(umi, {
+  const inscriptionAccount = findMintInscriptionPda(umi, {
     mint: mint.publicKey,
   });
-  const inscriptionMetadataAccount = await findInscriptionMetadataPda(umi, {
+  const inscriptionMetadataAccount = findInscriptionMetadataPda(umi, {
     inscriptionAccount: inscriptionAccount[0],
   });
 
@@ -200,4 +202,79 @@ test('it cannot set the wrong mint on a Mint Inscription account', async (t) => 
 
   // And it fails because the derivation from the wrong mint is invalid.
   await t.throwsAsync(promise, { name: 'DerivedKeyInvalid' });
+});
+
+test('it can mint from SPL Token 2022', async (t) => {
+  // Given a created NonFungible.
+  const umi = await createUmi();
+  umi.use(mplTokenMetadata());
+  const mint = generateSigner(umi);
+
+  await createV1(umi, {
+    mint,
+    name: 'My Programmable NFT',
+    uri: 'https://arweave.net/LcjCf-NDr5bhCJ0YMKGlc8m8qT_J6TDWtIuW8lbu0-A',
+    sellerFeeBasisPoints: percentAmount(5.5),
+    splTokenProgram: SPL_TOKEN_2022_PROGRAM_ID,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // And we derive the associated token account from SPL Token 2022.
+  const [token] = umi.eddsa.findPda(SPL_ASSOCIATED_TOKEN_PROGRAM_ID, [
+    publicKeySerializer().serialize(umi.identity.publicKey),
+    publicKeySerializer().serialize(SPL_TOKEN_2022_PROGRAM_ID),
+    publicKeySerializer().serialize(mint.publicKey),
+  ]);
+
+  // When we mint one token.
+  await mintV1(umi, {
+    mint: mint.publicKey,
+    token,
+    tokenOwner: umi.identity.publicKey,
+    splTokenProgram: SPL_TOKEN_2022_PROGRAM_ID,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  const inscriptionAccount = findMintInscriptionPda(umi, {
+    mint: mint.publicKey,
+  });
+  const inscriptionMetadataAccount = findInscriptionMetadataPda(umi, {
+    inscriptionAccount: inscriptionAccount[0],
+  });
+
+  let builder = new TransactionBuilder();
+
+  // When we create a new account.
+  builder = builder.append(
+    initializeFromMint(umi, {
+      mintAccount: mint.publicKey,
+    })
+  );
+
+  // Set the mint on the account.
+  builder = builder.append(
+    setMint(umi, {
+      mintInscriptionAccount: inscriptionAccount,
+      inscriptionMetadataAccount,
+      mintAccount: mint.publicKey,
+    })
+  );
+
+  await builder.sendAndConfirm(umi);
+
+  // Then an account was created with the correct data.
+  const inscriptionMetadata = await fetchInscriptionMetadata(
+    umi,
+    inscriptionMetadataAccount
+  );
+
+  t.like(inscriptionMetadata, <InscriptionMetadata>{
+    key: Key.MintInscriptionMetadataAccount,
+    inscriptionAccount: inscriptionAccount[0],
+    bump: inscriptionMetadataAccount[1],
+    dataType: DataType.Uninitialized,
+    updateAuthorities: [umi.identity.publicKey],
+    associatedInscriptions: [] as AssociatedInscription[],
+    mint: some(mint.publicKey),
+  });
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "programs:debug": "./configs/scripts/program/test.sh",
     "programs:clean": "./configs/scripts/program/clean.sh",
     "clients:rust:test": "./configs/scripts/client/test-rust.sh",
-    "clients:js:test": "./configs/sripts/client/test-js.sh",
+    "clients:js:test": "./configs/scripts/client/test-js.sh",
     "generate": "pnpm generate:idls && pnpm generate:clients",
     "generate:idls": "node ./configs/shank.cjs",
     "generate:clients": "node ./configs/kinobi.cjs",

--- a/programs/inscription/Cargo.lock
+++ b/programs/inscription/Cargo.lock
@@ -1041,12 +1041,13 @@ dependencies = [
  "borsh 0.10.3",
  "mpl-token-metadata",
  "mpl-utils",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "serde_json",
  "shank",
  "solana-program",
  "spl-token 4.0.0",
+ "spl-token-2022 0.8.0",
  "thiserror",
 ]
 
@@ -1057,7 +1058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
 dependencies = [
  "borsh 0.10.3",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "solana-program",
  "thiserror",
@@ -1065,13 +1066,13 @@ dependencies = [
 
 [[package]]
 name = "mpl-utils"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
+checksum = "5487a93ce5e3d1e0b5857772f0e605b1ba83d2fc776988f8b8aaffd360f016f7"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token-2022",
+ "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -1094,6 +1095,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1134,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive 0.7.2",
+]
+
+[[package]]
 name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1171,18 @@ name = "num_enum_derive"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -1727,7 +1760,7 @@ dependencies = [
  "log",
  "memoffset",
  "num-bigint",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "parking_lot",
  "rand 0.7.3",
@@ -1776,7 +1809,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "memmap2",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.6.1",
  "pbkdf2 0.11.0",
@@ -1831,7 +1864,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "merlin",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rand 0.7.3",
  "serde",
@@ -1845,12 +1878,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-discriminator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator-derive",
+]
+
+[[package]]
+name = "spl-discriminator-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fd7858fc4ff8fb0e34090e41d7eb06a823e1057945c26d480bfc21d2338a93"
+dependencies = [
+ "quote",
+ "spl-discriminator-syn",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "spl-discriminator-syn"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fea7be851bd98d10721782ea958097c03a0c2a07d8d4997041d0ece6319a63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.8",
+ "syn 2.0.38",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-memo"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
  "solana-program",
+]
+
+[[package]]
+name = "spl-memo"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
+name = "spl-pod"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
+dependencies = [
+ "borsh 0.10.3",
+ "bytemuck",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-program-error",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
+dependencies = [
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1845dfe71fd68f70382232742e758557afe973ae19e6c06807b2c30f5d5cb474"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.8",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7960b1e1a41e4238807fca0865e72a341b668137a3f2ddcd770d04fd1b374c96"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
 ]
 
 [[package]]
@@ -1861,7 +1990,7 @@ checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
  "solana-program",
@@ -1876,7 +2005,7 @@ checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.6.1",
  "solana-program",
@@ -1891,14 +2020,79 @@ checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-memo",
+ "spl-memo 3.0.1",
  "spl-token 3.5.0",
  "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fc0c7a763c3f53fa12581d07ed324548a771bb648a1217e4f330b1d0a59331"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum 0.7.2",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 4.0.0",
+ "spl-pod",
+ "spl-token 4.0.0",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
+ "spl-type-length-value",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7489940049417ae5ce909314bead0670e2a5ea5c82d43ab96dc15c8fcbbccba"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
 ]
 
 [[package]]

--- a/programs/inscription/Cargo.toml
+++ b/programs/inscription/Cargo.toml
@@ -16,7 +16,8 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 solana-program = "~1.16"
 thiserror = "^1.0"
-mpl-utils = "0.3.1"
+mpl-utils = "0.3.3"
 serde_json = { version = "1.0.108", features = ["std"] }
 mpl-token-metadata = "3.2.3"
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "0.8", features = ["no-entrypoint"] }

--- a/programs/inscription/src/processor/initialize_from_mint.rs
+++ b/programs/inscription/src/processor/initialize_from_mint.rs
@@ -1,7 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpl_token_metadata::accounts::Metadata;
 use mpl_utils::{
-    assert_derivation, assert_owned_by, assert_signer, create_or_allocate_account_raw,
+    assert_derivation, assert_owned_by, assert_owner_in, assert_signer,
+    create_or_allocate_account_raw, token::SPL_TOKEN_PROGRAM_IDS,
 };
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program_memory::sol_memcpy,
@@ -38,9 +39,9 @@ pub(crate) fn process_initialize_from_mint<'a>(accounts: &'a [AccountInfo<'a>]) 
         MplInscriptionError::IncorrectOwner,
     )?;
 
-    assert_owned_by(
+    assert_owner_in(
         ctx.accounts.mint_account,
-        &spl_token::ID,
+        &SPL_TOKEN_PROGRAM_IDS,
         MplInscriptionError::IncorrectOwner,
     )?;
 

--- a/programs/inscription/src/processor/set_mint.rs
+++ b/programs/inscription/src/processor/set_mint.rs
@@ -1,7 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use mpl_utils::{
-    assert_derivation, assert_owned_by, assert_signer, resize_or_reallocate_account_raw,
+    assert_derivation, assert_owner_in, assert_signer, resize_or_reallocate_account_raw,
+    token::SPL_TOKEN_PROGRAM_IDS,
 };
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program_memory::sol_memcpy,
@@ -33,9 +34,9 @@ pub(crate) fn process_set_mint<'a>(accounts: &'a [AccountInfo<'a>]) -> ProgramRe
         return Err(MplInscriptionError::NotInitialized.into());
     }
 
-    assert_owned_by(
+    assert_owner_in(
         ctx.accounts.mint_account,
-        &spl_token::ID,
+        &SPL_TOKEN_PROGRAM_IDS,
         MplInscriptionError::IncorrectOwner,
     )?;
 


### PR DESCRIPTION
the following packages prevent usage of spl\_token\_2022 v2.0:

*   mpl\_utils
    *   solana\_program >= 1.14, \< 1.17
    *   spl\_token\_2022 >0.6, \<0.9
*   spl\_token\_2022
    *   solana\_program >= 1.17

they are preventing the usage of more modern versions, however, I don't know whether it matters much so I decided to leave not invasive changes.